### PR TITLE
setting lastTimestamp on start()

### DIFF
--- a/tween.js
+++ b/tween.js
@@ -88,6 +88,7 @@ class Tween {
 
   start() {
     this.isRunning = true;
+    this.lastTimestamp = performance.now();
     this.startHandlers.forEach((handler) => {
       handler();
     });


### PR DESCRIPTION
I was unable to animate anything because the library would set the targetValue immediately.

`update(timestamp)` is called by the browser via requestAnimationFrame. Per spec it will provide a timestamp. According to MDN, this is the same number returned by `performance.now()`. In my case, interactive tweens never worked, because the `update()` function started a few seconds in, so it always just jumped to the end of an animation. Setting `this.lastTimestamp` to `performance.now()` on start means, that the exact value of `timestamp` does not matter. I have tested this in current firefox (102), Edge (103) and Chromium (103). I have not tested `pause()` and `resume()`.